### PR TITLE
chore: add spec version

### DIFF
--- a/spec/spec.md
+++ b/spec/spec.md
@@ -1,4 +1,4 @@
-# Linked Verifiable Presentations
+# Linked Verifiable Presentations v0.1.0
 
 **Specification Status:** [Draft](https://github.com/decentralized-identity/org/blob/master/work-item-lifecycle.md)
 


### PR DESCRIPTION
My understanding is that multiple versions can be rendered by duplicating the spec in the `spec.json` file: https://github.com/decentralized-identity/spec-up#version-numbering

Since we are still in the process of stabilizing the spec, I suggest we bump the version at each monthly meeting. Once the spec advances to the next status we should bump the version to `v1.0.0` and then start maintaining multiple version to ensure backward compatibility.

Closes #34